### PR TITLE
Explicitly include <stdio.h> at gen_context.c

### DIFF
--- a/src/gen_context.c
+++ b/src/gen_context.c
@@ -6,6 +6,8 @@
 
 #define USE_BASIC_CONFIG 1
 
+#include <stdio.h>
+
 #include "basic-config.h"
 #include "include/secp256k1.h"
 #include "util.h"


### PR DESCRIPTION
It was previously implicitly included via the "util.h" header file.