### PR TITLE
Use correct function names in documentation

### DIFF
--- a/src/modules/thresholdsig/threshold.md
+++ b/src/modules/thresholdsig/threshold.md
@@ -57,26 +57,24 @@ Key Generation works as follows.
 2. Each signer uses `secp256k1_musig_pubkey_combine` to compute the combined
    public key `P`. This function also outputs a list `Y_i` of tweaked public
    keys, which will be needed to validate partial signatures.
-3. Each signer modifies her secret key using `secp256k1_musig_tweak_secret_key`
-   to produce a secret key `y_i` compatible with her public key `Y_i`.
 
 Assuming the participants agree beforehand on the set of public keys, there
 is no interaction required. However, if the threshold `k` is less than `n`,
 there are two additional rounds of interaction required, across the following
 four steps.
 
-4. Each participant splits her secret key `secp256k1_musig_keysplit`. This
-   function outputs an array of private _keyshards_, one for each participant,
-   as well as an array of _public coefficients_ which must be broadcast to all
-   other signers.
+4. Each participant splits her secret key `secp256k1_thresholdsig_keysplit`.
+   This function outputs an array of private _keyshards_, one for each
+   participant, as well as an array of _public coefficients_ which must be
+   broadcast to all other signers.
 5. Each participant, upon receiving a private keyshard and a set of public
-   coefficients, runs `secp256k1_musig_verify_shard` to check consistency
+   coefficients, runs `secp256k1_thresholdsig_verify_shard` to check consistency
    of these. This function outputs a modified set of public keys `{Z_i}`
    and a modified secret key `z_i`, which the signer should use in place of
    the keys produced in steps 2 and 3. (Specifically, on the first invocation
-   `secp256k1_musig_verify_shard` outputs keys which it updates on subsequent
-   invocations, until all participants' shards and coefficients have been
-   taken into account.)
+   `secp256k1_thresholdsig_verify_shard` outputs keys which it updates on
+   subsequent invocations, until all participants' shards and coefficients have
+   been taken into account.)
 6. [TODO] She signs the each set of coefficients and broadcasts her signatures.
 7. [TODO] each participant verifies each others' signatures.
 
@@ -106,39 +104,41 @@ verify_signature
 To produce a signature, each signer `i` acts as follows.
 
 1. Produces a nonce pair `(k_i, R_i)` and a commitment (hash) `C_i` to `R_i`.
-   This is done with `secp256k1_musig_multisig_generate_nonce`. Sends the
-   commitment `C_i` to every other signer.
+   This is done with `secp256k1_thresholdsig_session_initialize` and the
+   nonce can be obtained with `secp256k1_musig_session_get_public_nonce`.
+   Sends the commitment `C_i` to every other signer.
 2. Once at least `k` nonce commitments have been received from other signers,
-   signer `i` creates `n` `secp256k1_musig_signer_data` structures, one for
-   each signer including herself.
-   She initializes each with `secp256k1_musig_signer_data_initialize` which
+   signer `i` creates `n` `secp256k1_musig_session_signer_data` structures, one
+   for each signer including herself.
+   She initializes each with `secp256k1_thresholdsig_session_initialize` which
    takes a public key from all signers and a nonce commitment from present
    signers. If `k = n`, the public key should be `Y_i` from step 2 of the key
    setup; otherwise it should be `Z_i` from step 5 of key setup.
 3. She sends her actual public nonce `R_i` to every other signer.
-4. Upon receipt of another signer's public nonce, she calls `secp256k1_musig_set_nonce`
-   to update that signer's data structure. If the public nonce does not match
-   the precommitment, this function will fail and the signer will be considered
-   not to be present.
+4. Upon receipt of another signer's public nonce, she calls
+   `secp256k1_musig_set_nonce` to update that signer's data structure.
+   If the public nonce does not match the precommitment, this function will fail
+   and the signer will be considered not to be present.
 5. Once `k` valid public nonces have been received, she can produce a partial
-   signature using `secp256k1_musig_partial_sign`. She sends this partial signature
-   to someone (or everyone) for aggregation.
+   signature using `secp256k1_musig_partial_sign`. She sends this partial
+   signature to someone (or everyone) for aggregation.
    [TODO] Things will work with more than `k` signers; if people disagree on the
    set of signers this is a problem, so "just take the first `k`" is actually
    likely to fail in the case of `>k`.
 6. Some participant receives all the partial signatures and combines them using
-   `secp256k1_musig_combine_partial_sigs`. The output of this function is a
+   `secp256k1_musig_partial_sig_combine`. The output of this function is a
    complete signature. If the signature is invalid, at least one of the partial
    signatures was invalid. The culprit may be identified using the function
-   `secp256k1_musig_partial_sig_verify` on the individual partial signatures.
+   `secp256k1_thresholdsig_partial_sig_verify` on the individual partial
+   signatures.
 
 Signing Procedure Flowchart:
 ```
 Me:                           Others:
 
-multisig_generate_nonce C ->
-                           <- multisig_generate_nonce C
-signer_data_initialize
+session_initialize C    ->
+                           <- session_initialize C
+musig_get_public_nonce
 R                         ->
                            <- R
 partial_sign              ->
@@ -165,9 +165,10 @@ In the case of threshold signatures, construction is a bit more involved. To
 recall terminology, signer `i` has tweaked secret key `y_i`, tweaked public key
 `Y_i`, and the total key is `P = sum_i Y_i` with the sum taken over all signers.
 
-When splitting her secret key `y_i`, signer `i` calls `secp256k1_musig_keysplit`,
-which outputs two things. First, a set of _private shards_ `y_i,j`, one for each
-signer `j`, which satisfies the following equation
+When splitting her secret key `y_i`, signer `i` calls
+`secp256k1_thresholdsig_keysplit`, which outputs two things. First, a set of
+_private shards_ `y_i,j`, one for each signer `j`, which satisfies the following
+equation
 
     y_i = sum_j L_j * y_i,j                              (1)
 
@@ -175,18 +176,18 @@ with the sum taken any subset of `k` or more signers. The coefficients `L_j`
 depend on the subset chosen, but the shards and total key do not. The details
 of determining these coefficients are given in the next section.
 
-Second, `secp256k1_musig_keysplit` outputs a set of _public coefficients_,
+Second, `secp256k1_thresholdsig_keysplit` outputs a set of _public coefficients_,
 which are curvepoints `P_n` satisfying
 
     y_i,j*G = sum_{n=0}^{k-1} j^n * P_n                    (2)
 
-This is equation `(*)` from [3]. What `secp256k1_musig_verify_shard` does is
-to check this equation for the shard `y_i,j` that signer `j` has possession
+This is equation `(*)` from [3]. What `secp256k1_thresholdsig_verify_shard` does
+is to check this equation for the shard `y_i,j` that signer `j` has possession
 of, and also uses the equation to compute
 
     Z_j = sum_i y_i,j*G                                  (3)
 
-That is, `secp256k1_musig_verify_shard` computes the public key equivalent
+That is, `secp256k1_thresholdsig_verify_shard` computes the public key equivalent
 of all signers' shards of all signers keys, checks that the caller's private
 shards are consistent with the computed public shards, and then sums them up.
 
@@ -209,9 +210,10 @@ Therefore, after key setup, each signer's secret key is replaced with `z_j`,
 the sum of their shards, and public key is replaced by `Z_j`, which can be
 computed by everyone.
 
-During signing, `secp256k1_musig_signer_data_initialize` and `secp256k1_musig_set_nonce`
-track which signers are present and which are missing. If at least `k` signers are
-present, this uniquely determines a set `L_j` of Lagrange coefficients.
+During signing, `secp256k1_thresholdsig_session_initialize` and
+`secp256k1_musig_set_nonce` track which signers are present and which are missing.
+If at least `k` signers are present, this uniquely determines a set `L_j` of
+Lagrange coefficients.
 
 Each signer `j` calls `secp256k1_musig_partial_sign` to sign. When computing the
 total nonce, it uses the equation
@@ -223,7 +225,7 @@ The signature is computed as
 
     s_j = k_j + z_j * e
 
-Finally, in `secp256k1_musig_combine_partial_sigs`, each signature is multiplied by
+Finally, in `secp256k1_musig_partial_sig_combine`, each signature is multiplied by
 `L_j`, resulting in a total signature that satisfies
 
     s*G = sum_j L_j * s_j * G


### PR DESCRIPTION
While reading the documentation I noticed some function names have changed since this text was written. I hope I picked the right ones.

Some line breaks had to be changed too as to respect the maximum line length.