### PR TITLE
bulletproofs: expose a macro returning proof-size

### DIFF
--- a/include/secp256k1_bulletproofs.h
+++ b/include/secp256k1_bulletproofs.h
@@ -10,11 +10,17 @@ extern "C" {
 
 #include <stdint.h>
 
+/** A function-like macro returning the size, in bytes, of an uncompressed
+ * Bulletproof proving that a value lies in the range [0, 2^(n_bits) - 1]
+ */
+#define SECP256K1_BULLETPROOFS_UNCOMPRESSED_SIZE(n_bits) (194UL + (n_bits) * 64)
+
 /** Maximum size, in bytes, of an uncompressed rangeproof */
 extern const size_t SECP256K1_BULLETPROOFS_RANGEPROOF_UNCOMPRESSED_MAX_LENGTH;
 
 /** The same value, as a C macro so it can be used as C89 array size */
-#define SECP256K1_BULLETPROOFS_RANGEPROOF_UNCOMPRESSED_MAX_LENGTH_ (194 + 4096)
+#define SECP256K1_BULLETPROOFS_RANGEPROOF_UNCOMPRESSED_MAX_LENGTH_ \
+    SECP256K1_BULLETPROOFS_UNCOMPRESSED_SIZE(64)
 
 /** Opaque data structure that holds the current state of an uncompressed
  * Bulletproof proof generation. This data is not secret and does not need


### PR DESCRIPTION
This PR adds a convenience macro enabling callers to allocate the
necessary and sufficient space for an uncompressed rangeproof. In
particular, this makes it tractible to avoid pessimistically
over-allocating the maximum possible space an uncompressed
rangeproof might ever occupy.

Also, SECP256K1_BULLETPROOFS_RANGEPROOF_UNCOMPRESSED_MAX_LENGTH_ is
redefined as a short-cut leveraging the new convenience macro. This
both makes clear from where the maximum length is derived, and
should avoid the two macros drifting apart should the expected size
change (e.g., if compression is supported in the future).